### PR TITLE
Refactor tables with shared components

### DIFF
--- a/web/components/admin/customer/customer-pagination.tsx
+++ b/web/components/admin/customer/customer-pagination.tsx
@@ -1,81 +1,19 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCustomerStore } from "@/stores/customer-store";
+import { TablePagination } from "@/components/shared/table-pagination";
 
 export function CustomerPagination() {
   const { total, pagination, setPagination } = useCustomerStore();
 
-  const totalPages = total > 0 ? Math.ceil(total / pagination.pageSize) : 0;
-  if (total === 0 && totalPages === 0) return null;
-
-  const currentPage = pagination.pageIndex + 1;
-
-  const handlePageChange = (newPageIndex: number) => {
-    if (newPageIndex >= 0 && newPageIndex < totalPages) {
-      setPagination({ pageIndex: newPageIndex });
-    }
-  };
-
-  const handlePageSizeChange = (newPageSize: string) => {
-    setPagination({ pageIndex: 0, pageSize: Number.parseInt(newPageSize) });
-  };
-
   return (
-    <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-4 px-2">
-      <div className="text-sm text-gray-600">
-        แสดง {pagination.pageIndex * pagination.pageSize + 1} ถึง{" "}
-        {Math.min((pagination.pageIndex + 1) * pagination.pageSize, total)} จาก {total} รายการ
-      </div>
-
-      <div className="flex items-center space-x-4">
-        <div className="flex items-center space-x-2">
-          <p className="text-sm font-medium">Rows per page</p>
-          <Select
-            value={`${pagination.pageSize}`} onValueChange={(value) => {
-              handlePageSizeChange(value);
-            }}
-          >
-            <SelectTrigger className="h-8 w-[70px]">
-              <SelectValue placeholder={pagination.pageSize} />
-            </SelectTrigger>
-            <SelectContent side="top">
-              {[10, 20, 30, 40, 50].map((pageSize) => (
-                <SelectItem key={pageSize} value={`${pageSize}`}>
-                  {pageSize}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex items-center justify-center text-sm font-medium">
-          Page {currentPage} of {totalPages === 0 ? 1 : totalPages}
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Button
-            variant="outline"
-            className="h-8 w-8 p-0"
-            onClick={() => handlePageChange(pagination.pageIndex - 1)}
-            disabled={pagination.pageIndex === 0 || totalPages === 0}
-          >
-            <span className="sr-only">Go to previous page</span>
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="outline"
-            className="h-8 w-8 p-0"
-            onClick={() => handlePageChange(pagination.pageIndex + 1)}
-            disabled={currentPage === totalPages || totalPages === 0}
-          >
-            <span className="sr-only">Go to next page</span>
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
+    <TablePagination
+      total={total}
+      pagination={pagination}
+      onPageChange={(page) => setPagination({ pageIndex: page })}
+      onPageSizeChange={(size) => setPagination({ pageIndex: 0, pageSize: size })}
+      pageSizeOptions={[10, 20, 30, 40, 50]}
+      className="px-2"
+    />
   );
 }

--- a/web/components/admin/customer/customer-table-skeleton.tsx
+++ b/web/components/admin/customer/customer-table-skeleton.tsx
@@ -1,41 +1,5 @@
-import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { TableSkeleton } from "@/components/shared/table-skeleton";
 
 export function CustomerTableSkeleton() {
-  const numRows = 8; // Number of skeleton rows to display
-  const numCells = 4; // Number of columns: Name, Email, Status, Actions
-
-  return (
-    <div className="rounded-md border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            {Array.from({ length: numCells }).map((_, index) => (
-              <TableHead key={`header-skel-${index}`}>
-                <Skeleton className="h-5 w-full" />
-              </TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {Array.from({ length: numRows }).map((_, rowIndex) => (
-            <TableRow key={`row-skel-${rowIndex}`}>
-              {Array.from({ length: numCells }).map((_, cellIndex) => (
-                <TableCell key={`cell-skel-${rowIndex}-${cellIndex}`}>
-                  <Skeleton className="h-5 w-full" />
-                </TableCell>
-              ))}
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
-  );
+  return <TableSkeleton columns={4} />;
 }

--- a/web/components/admin/customer/customer-table.tsx
+++ b/web/components/admin/customer/customer-table.tsx
@@ -1,72 +1,12 @@
 "use client";
 
-import * as React from "react";
-import {
-  Table as TanstackTable, // Renaming to avoid conflict with local Table component
-  flexRender,
-} from "@tanstack/react-table";
-
-import {
-  Table, // This is the ShadCN UI Table component
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import type { Table as TanstackTable } from "@tanstack/react-table";
+import { DataTable } from "@/components/shared/data-table";
 
 interface DataTableProps<TData> {
-  table: TanstackTable<TData>; // Expect the fully configured table instance
-  // columns prop is implicitly part of the table instance
+  table: TanstackTable<TData>;
 }
 
-export function CustomerTable<TData>({
-  table,
-}: DataTableProps<TData>) {
-  return (
-    <div className="rounded-md border">
-      <Table> {/* Using ShadCN UI Table component */}
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHead key={header.id} style={{ width: header.getSize() !== 0 ? header.getSize() : undefined }}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
-                  </TableHead>
-                );
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows?.length ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow
-                key={row.id}
-                data-state={row.getIsSelected() && "selected"}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={table.getAllColumns().length} className="h-24 text-center">
-                No customers found.
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-    </div>
-  );
+export function CustomerTable<TData>({ table }: DataTableProps<TData>) {
+  return <DataTable table={table} noDataMessage="No customers found." />;
 }

--- a/web/components/parcel/parcel-pagination.tsx
+++ b/web/components/parcel/parcel-pagination.tsx
@@ -1,75 +1,17 @@
 "use client"
 
-import { type Table } from "@tanstack/react-table"
-import { Button } from "@/components/ui/button"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { ChevronLeft, ChevronRight } from "lucide-react"
 import { useParcelStore } from "@/stores/parcel-store"
-
+import { TablePagination } from "@/components/shared/table-pagination"
 
 export function ParcelPagination() {
   const { total = 0, pagination, setPagination } = useParcelStore()
 
-  const totalPages = total > 0 ? Math.ceil(total / pagination.pageSize) : 0
-  if (total === 0) return null
-  const currentPage = pagination.pageIndex + 1
-
-  const handlePageChange = (newPage: number) => {
-    setPagination({ pageIndex: newPage - 1 })
-  }
-
-  const handlePageSizeChange = (newPageSize: string) => {
-    setPagination({ pageIndex: 0, pageSize: Number.parseInt(newPageSize) })
-  }
-
   return (
-    <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-4">
-      <div className="text-sm text-gray-600">
-        แสดง {pagination.pageIndex * pagination.pageSize + 1} ถึง{" "}
-        {Math.min((pagination.pageIndex + 1) * pagination.pageSize, total)} จาก {total} รายการ
-      </div>
-
-      <div className="flex items-center space-x-4">
-        <div className="flex items-center space-x-2">
-          <span className="text-sm">แสดงต่อหน้า:</span>
-          <Select value={pagination.pageSize.toString()} onValueChange={handlePageSizeChange}>
-            <SelectTrigger className="w-20">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {[10, 20, 50].map((size) => (
-                <SelectItem key={size} value={size.toString()}>
-                  {size}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => handlePageChange(currentPage - 1)}
-            disabled={currentPage === 1 || totalPages === 0}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </Button>
-
-          <span className="text-sm">
-            หน้า {currentPage} จาก {totalPages}
-          </span>
-
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => handlePageChange(currentPage + 1)}
-            disabled={currentPage === totalPages || totalPages === 0}
-          >
-            <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-    </div>
+    <TablePagination
+      total={total}
+      pagination={pagination}
+      onPageChange={(page) => setPagination({ pageIndex: page - 1 })}
+      onPageSizeChange={(size) => setPagination({ pageIndex: 0, pageSize: size })}
+    />
   )
 }

--- a/web/components/parcel/parcel-table-skeleton.tsx
+++ b/web/components/parcel/parcel-table-skeleton.tsx
@@ -1,41 +1,5 @@
-import { Skeleton } from "@/components/ui/skeleton";
+import { TableSkeleton } from "@/components/shared/table-skeleton";
 
 export function ParcelTableSkeleton() {
-  const numRows = 8; // Display 8 skeleton rows
-  const numCells = 10; // Assume around 10 columns for the skeleton
-
-  return (
-    <div className="rounded-md border bg-white">
-      <div className="overflow-x-auto">
-        <table className="w-full min-w-[1200px]">
-          <thead>
-            <tr className="border-b bg-gray-50">
-              {Array.from({ length: numCells }).map((_, index) => (
-                <th
-                  key={`header-skel-${index}`}
-                  className="px-3 sm:px-4 py-3 text-left text-xs sm:text-sm font-medium text-gray-900"
-                >
-                  <Skeleton className="h-5 w-24" />
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {Array.from({ length: numRows }).map((_, rowIndex) => (
-              <tr key={`row-skel-${rowIndex}`} className="border-b hover:bg-gray-50">
-                {Array.from({ length: numCells }).map((_, cellIndex) => (
-                  <td
-                    key={`cell-skel-${rowIndex}-${cellIndex}`}
-                    className="px-3 sm:px-4 py-3 text-xs sm:text-sm"
-                  >
-                    <Skeleton className="h-5 w-full" />
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
+  return <TableSkeleton columns={10} />;
 }

--- a/web/components/parcel/parcel-table.tsx
+++ b/web/components/parcel/parcel-table.tsx
@@ -1,62 +1,12 @@
 "use client"
 
-import {
-  type Table, // To type the table prop
-  flexRender,
-} from "@tanstack/react-table"
+import type { Table } from "@tanstack/react-table"
+import { DataTable } from "@/components/shared/data-table"
 
 interface ParcelTableProps<TData> {
   table: Table<TData>
 }
 
 export function ParcelTable<TData>({ table }: ParcelTableProps<TData>) {
-  const hasRows = table.getRowModel().rows && table.getRowModel().rows.length > 0
-  return (
-    <div className="rounded-md border bg-white">
-      {hasRows ? (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[1200px]">
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id} className="border-b bg-gray-50">
-                  {headerGroup.headers.map((header) => (
-                    <th
-                      key={header.id}
-                      className="px-3 sm:px-4 py-3 text-left text-xs sm:text-sm font-medium text-gray-900"
-                      style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
-                    >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                    </th>
-                  ))}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => (
-                <tr key={row.id} className="border-b hover:bg-gray-50">
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className="px-3 sm:px-4 py-3 text-xs sm:text-sm">
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <div className="text-center py-8 text-gray-500 text-sm sm:text-base">
-          ไม่พบข้อมูล
-        </div>
-      )}
-    </div>
-  )
+  return <DataTable table={table} />
 }

--- a/web/components/shared/data-table.tsx
+++ b/web/components/shared/data-table.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { flexRender, Table as TanStackTable } from "@tanstack/react-table"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+interface DataTableProps<TData> {
+  table: TanStackTable<TData>
+  noDataMessage?: React.ReactNode
+  className?: string
+}
+
+export function DataTable<TData>({ table, noDataMessage, className }: DataTableProps<TData>) {
+  const hasRows = table.getRowModel().rows.length > 0
+
+  return (
+    <div className="rounded-md border bg-white">
+      <Table className={className ?? "min-w-[1200px]"}>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id} className="bg-gray-50">
+              {headerGroup.headers.map((header) => (
+                <TableHead
+                  key={header.id}
+                  style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
+                >
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {hasRows ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={table.getAllColumns().length} className="h-24 text-center">
+                {noDataMessage ?? "ไม่พบข้อมูล"}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/web/components/shared/table-pagination.tsx
+++ b/web/components/shared/table-pagination.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import type { PaginationState } from "@/lib/types"
+
+interface TablePaginationProps {
+  total: number
+  pagination: PaginationState
+  onPageChange: (pageIndex: number) => void
+  onPageSizeChange: (pageSize: number) => void
+  pageSizeOptions?: number[]
+  className?: string
+}
+
+export function TablePagination({
+  total,
+  pagination,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [10, 20, 50],
+  className,
+}: TablePaginationProps) {
+  const totalPages = total > 0 ? Math.ceil(total / pagination.pageSize) : 0
+  if (total === 0) return null
+  const currentPage = pagination.pageIndex + 1
+
+  return (
+    <div className={"flex flex-col sm:flex-row items-center justify-between gap-4 mt-4 " + (className ?? "")}>
+      <div className="text-sm text-gray-600">
+        แสดง {pagination.pageIndex * pagination.pageSize + 1} ถึง{' '}
+        {Math.min((pagination.pageIndex + 1) * pagination.pageSize, total)} จาก {total} รายการ
+      </div>
+
+      <div className="flex items-center space-x-4">
+        <div className="flex items-center space-x-2">
+          <span className="text-sm">แสดงต่อหน้า:</span>
+          <Select value={pagination.pageSize.toString()} onValueChange={(val) => onPageSizeChange(Number(val))}>
+            <SelectTrigger className="w-20">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {pageSizeOptions.map((size) => (
+                <SelectItem key={size} value={size.toString()}>{size}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 1 || totalPages === 0}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+
+          <span className="text-sm">
+            หน้า {currentPage} จาก {totalPages}
+          </span>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages || totalPages === 0}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/components/shared/table-skeleton.tsx
+++ b/web/components/shared/table-skeleton.tsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+interface TableSkeletonProps {
+  rows?: number
+  columns?: number
+  className?: string
+}
+
+export function TableSkeleton({ rows = 8, columns = 5, className }: TableSkeletonProps) {
+  return (
+    <div className="rounded-md border bg-white">
+      <Table className={className ?? "min-w-[1200px]"}>
+        <TableHeader>
+          <TableRow className="bg-gray-50">
+            {Array.from({ length: columns }).map((_, index) => (
+              <TableHead key={`header-skel-${index}`}>
+                <Skeleton className="h-5 w-full" />
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: rows }).map((_, rowIndex) => (
+            <TableRow key={`row-skel-${rowIndex}`}>
+              {Array.from({ length: columns }).map((_, cellIndex) => (
+                <TableCell key={`cell-skel-${rowIndex}-${cellIndex}`}>
+                  <Skeleton className="h-5 w-full" />
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add generic `DataTable`, `TablePagination`, and `TableSkeleton`
- refactor parcel pages to use shared components
- refactor customer pages to use shared components

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce0d6df48330a28b74dd4964587a