### PR TITLE
Rename refetchCustomers to refetch in customer hook

### DIFF
--- a/web/app/admin/customers/page.tsx
+++ b/web/app/admin/customers/page.tsx
@@ -36,7 +36,7 @@ export default function AdminCustomersPage() {
   const {
     customers,
     loading,
-    refetchCustomers,
+    refetch,
   } = useCustomers();
 
   // Get setters and specific actions directly from the store
@@ -125,7 +125,7 @@ export default function AdminCustomersPage() {
         if (newCustomer) {
           showToast("Customer created successfully!", "success");
           setIsFormModalOpen(false);
-          refetchCustomers(); // Refetch the list
+          refetch(); // Refetch the list
         }
         // Error toast is handled by withErrorHandling from service if it throws
       }

--- a/web/components/admin/customer/customer-filters.tsx
+++ b/web/components/admin/customer/customer-filters.tsx
@@ -5,11 +5,15 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useCustomers } from "@/hooks/use-customers";
+import { useCustomerStore } from "@/stores/customer-store";
 import { UserStatus } from "@/lib/types"; // Assuming UserStatus is defined here
 import { Search, X } from "lucide-react";
 
 export function CustomerFilters() {
-  const { filters, setFilters, refetchCustomers, resetFilters: storeResetFilters } = useCustomers();
+  const { refetch } = useCustomers();
+  const filters = useCustomerStore((state) => state.filters);
+  const setFilters = useCustomerStore((state) => state.setFilters);
+  const storeResetFilters = useCustomerStore((state) => state.resetFilters);
 
   // Local state to control input fields before triggering a search (debounced or on button click)
   const [localSearch, setLocalSearch] = useState(filters.name || filters.email || "");
@@ -36,8 +40,8 @@ export function CustomerFilters() {
       status: localStatus === "all" ? undefined : localStatus,
     };
     setFilters(newFilters);
-    // refetchCustomers will be called by the useEffect in useCustomers due to filters changing
-    // Or, explicitly call it: refetchCustomers(newFilters);
+    // refetch will be called by the useEffect in useCustomers due to filters changing
+    // Or, explicitly call it: refetch();
   };
 
   const handleResetFilters = () => {

--- a/web/hooks/use-customers.ts
+++ b/web/hooks/use-customers.ts
@@ -12,11 +12,11 @@ export function useCustomers() {
     loading,
     filters,
     pagination,
-    setCustomers, // Renamed from setFetchedData
+    setCustomers,
     setLoading,
     setError,
-    error: customerStoreError, // Store's own error state
-    // setSelectedCustomer is selected below for direct return
+    error: customerStoreError,
+    setSelectedCustomer,
   } = useCustomerStore();
 
   // Mimic loadParcels structure for loadCustomers
@@ -97,17 +97,12 @@ export function useCustomers() {
   }, [loadCustomers]); // useEffect depends on the memoized loadCustomers
 
   return {
-    // State selected for optimized re-renders, as in useParcels
     customers: useCustomerStore((state) => state.customers),
     total: useCustomerStore((state) => state.total),
-
-    // Directly returned states from the hook's own scope or direct store selection
-    loading: useCustomerStore((state) => state.loading), // Ensure we get the latest loading state
-    error: useCustomerStore((state) => state.error),     // Ensure we get the latest error state
-
-    // Actions: only refetch and setSelectedCustomer, as per useParcels
-    refetchCustomers: loadCustomers,
-    setSelectedCustomer: useCustomerStore((state) => state.setSelectedCustomer),
+    loading,
+    error: customerStoreError,
+    refetch: loadCustomers,
+    setSelectedCustomer,
 
     // Pagination and Filters state are also needed by components using the table
     // useParcels does not explicitly return these, implying components get them from useParcelStore directly.


### PR DESCRIPTION
## Summary
- rename returned field from `refetchCustomers` to `refetch`
- expose Zustand actions directly in `useCustomers`
- update pages and components to use new `refetch` field

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce08680c83309835387c4be01cc9