### PR TITLE
Use store filters in admin customer UI

### DIFF
--- a/web/components/admin/customer/customer-filters.tsx
+++ b/web/components/admin/customer/customer-filters.tsx
@@ -5,11 +5,14 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useCustomers } from "@/hooks/use-customers";
+import { useCustomerStore } from "@/stores/customer-store";
 import { UserStatus } from "@/lib/types"; // Assuming UserStatus is defined here
 import { Search, X } from "lucide-react";
 
 export function CustomerFilters() {
-  const { filters, setFilters, refetchCustomers, resetFilters: storeResetFilters } = useCustomers();
+  // useCustomers is still invoked so its effect will refetch when filters change
+  const { refetchCustomers } = useCustomers();
+  const { filters, setFilters, resetFilters: storeResetFilters } = useCustomerStore();
 
   // Local state to control input fields before triggering a search (debounced or on button click)
   const [localSearch, setLocalSearch] = useState(filters.name || filters.email || "");


### PR DESCRIPTION
## Summary
- get filter state from `useCustomerStore` rather than `useCustomers`
- keep calling `useCustomers` so filter changes still trigger its effect

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce0ee03483309922e8a8df3eff81