### PR TITLE
Add mock users API and improve error handling

### DIFF
--- a/web/app/admin/customers/page.tsx
+++ b/web/app/admin/customers/page.tsx
@@ -163,15 +163,13 @@ export default function AdminCustomersPage() {
           {loading ? (
             <>
               <CustomerTableSkeleton />
-              <div className="mt-4">
-                {/* You might want a pagination skeleton or hide it during initial full load */}
-                {/* <CustomerPagination /> */}
-              </div>
             </>
           ) : (
             <>
-              {/* <CustomerTable table={table} />
-              <CustomerPagination /> */}
+              <CustomerTable table={table} />
+              <div className="mt-4">
+                <CustomerPagination />
+              </div>
             </>
           )}
         </div>

--- a/web/app/api/users/route.ts
+++ b/web/app/api/users/route.ts
@@ -1,0 +1,35 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import type { CustomerListResponse } from '@/lib/types';
+import { getCustomerListResponse } from '../utils';
+import { ApiResponse } from '@/lib/apiTypes';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const page = Number.parseInt(searchParams.get('page') || '1');
+    const limit = Number.parseInt(searchParams.get('limit') || '10');
+    const name = searchParams.get('name') || undefined;
+    const email = searchParams.get('email') || undefined;
+    const status = searchParams.get('status') || undefined;
+
+    const response: ApiResponse<CustomerListResponse> = getCustomerListResponse({
+      page,
+      limit,
+      name,
+      email,
+      status: status as any,
+    });
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error('API Error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'เกิดข้อผิดพลาดในการดึงข้อมูล',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/web/app/api/utils.ts
+++ b/web/app/api/utils.ts
@@ -1,5 +1,13 @@
 import { ApiResponse } from '@/lib/apiTypes';
-import { UserRole, type Parcel, type ParcelListResponse, type User } from '@/lib/types';
+import {
+  UserRole,
+  UserStatus,
+  type Parcel,
+  type ParcelListResponse,
+  type Customer,
+  type CustomerListResponse,
+  type User,
+} from '@/lib/types';
 
 export const mockAdminUser: User = {
   id: 'admin-1',
@@ -13,6 +21,93 @@ export const mockCustomerUser: User = {
   role: UserRole.CUSTOMER,
   customerCode: 'C001',
 };
+
+export const mockCustomers: Customer[] = [
+  {
+    id: '1',
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '0800000001',
+    customerCode: 'C001',
+    address: '123 Mockingbird Lane',
+    role: UserRole.CUSTOMER,
+    status: UserStatus.ACTIVE,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: '2',
+    name: 'Jane Smith',
+    email: 'jane@example.com',
+    phone: '0800000002',
+    customerCode: 'C002',
+    address: '456 Example Rd',
+    role: UserRole.CUSTOMER,
+    status: UserStatus.INACTIVE,
+    createdAt: '2024-01-02T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+  },
+  {
+    id: '3',
+    name: 'Bob Lee',
+    email: 'bob@example.com',
+    phone: '0800000003',
+    customerCode: 'C003',
+    address: '789 Demo Street',
+    role: UserRole.CUSTOMER,
+    status: UserStatus.ACTIVE,
+    createdAt: '2024-01-03T00:00:00Z',
+    updatedAt: '2024-01-03T00:00:00Z',
+  },
+];
+
+export interface CustomerFilterOptions {
+  page?: number;
+  limit?: number;
+  name?: string;
+  email?: string;
+  status?: UserStatus;
+}
+
+export function getCustomerListResponse(options: CustomerFilterOptions = {}): ApiResponse<CustomerListResponse> {
+  const { page = 1, limit = 10, name, email, status } = options;
+
+  let filteredCustomers = [...mockCustomers];
+
+  if (name) {
+    const lower = name.toLowerCase();
+    filteredCustomers = filteredCustomers.filter((c) => c.name.toLowerCase().includes(lower));
+  }
+
+  if (email) {
+    const lower = email.toLowerCase();
+    filteredCustomers = filteredCustomers.filter((c) => c.email.toLowerCase().includes(lower));
+  }
+
+  if (status) {
+    filteredCustomers = filteredCustomers.filter((c) => c.status === status);
+  }
+
+  const startIndex = (page - 1) * limit;
+  const paginatedCustomers = filteredCustomers.slice(startIndex, startIndex + limit);
+
+  const totalPages = Math.ceil(filteredCustomers.length / limit);
+
+  return {
+    resultCode: 20000,
+    resultStatus: 'Success',
+    developerMessage: 'Success',
+    resultData: {
+      data: paginatedCustomers,
+      pagination: {
+        total: filteredCustomers.length,
+        page,
+        limit,
+        totalPages,
+      },
+    },
+  };
+}
 
 export const mockParcels: Parcel[] = [
   {

--- a/web/services/apiService.ts
+++ b/web/services/apiService.ts
@@ -1,4 +1,5 @@
 import { useGlobalErrorStore } from '@/stores/globalErrorStore';
+import { showToast } from '@/lib/toast-utils';
 
 type ApiServiceFunction<T extends any[], R> = (...args: T) => Promise<R>;
 
@@ -14,6 +15,9 @@ export function withErrorHandling<T extends any[], R>(
       // Accessing Zustand store outside of React component/hook:
       // https://github.com/pmndrs/zustand#readingwriting-state-outside-of-components
       useGlobalErrorStore.getState().setError(errorMessage);
+      if (typeof window !== 'undefined') {
+        showToast(errorMessage, 'error');
+      }
 
       console.error('API Error (handled by withErrorHandling):', error);
       throw error; // Re-throw the error so the caller can also handle it if needed


### PR DESCRIPTION
## Summary
- show toast notifications on API errors
- provide mock user list via new `/api/users` route
- update mock data utilities with sample customers
- display customer table and pagination in admin page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d91e35e4833087155718b0657c9a