### PR TITLE
UI polish for admin tables

### DIFF
--- a/web/app/admin/customers/page.tsx
+++ b/web/app/admin/customers/page.tsx
@@ -125,9 +125,11 @@ export default function AdminCustomersPage() {
 
   return (
     <DashboardLayout breadcrumbs={breadcrumbs}>
-      <div className="space-y-6 sm:space-y-8">
+      <div className="space-y-5 sm:space-y-6">
         <div className="stagger-item">
-          <h1 className="text-xl sm:text-heading font-bold text-[#212121] mb-1 sm:mb-2">
+          <h1
+            className="text-xl sm:text-heading font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent mb-1 sm:mb-2"
+          >
             Customer Management
           </h1>
           <p className="text-sm sm:text-subtitle text-gray-600 font-normal">
@@ -139,28 +141,25 @@ export default function AdminCustomersPage() {
           <h2 className="text-lg sm:text-title font-semibold text-[#212121]">รายชื่อลูกค้า</h2>
           <Button
             onClick={handleOpenCreateModal}
-            className="ripple bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium px-4 sm:px-6 py-2 sm:py-3 rounded-xl shadow-material-4 transition-all duration-300 hover:shadow-material-8 touch-target w-full sm:w-auto"
+            className="ripple bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-medium px-4 sm:px-5 py-2 rounded-lg shadow-material-4 transition-all duration-300 hover:shadow-material-8 touch-target w-full sm:w-auto"
           >
-            <Plus className="h-4 w-4 sm:h-5 sm:w-5 mr-2" />
-            <span className="text-sm sm:text-base">Add New User</span>
+            <Plus className="h-4 w-4 mr-2" />
+            <span className="text-sm">Add New User</span>
           </Button>
         </div>
 
         <div className="stagger-item">
-          <CustomerFilters />
-        </div>
-
-        <div className="stagger-item">
           {loading ? (
-            <div className="space-y-4 sm:space-y-6">
+            <div className="space-y-3 sm:space-y-4">
               <div className="glass-effect rounded-2xl overflow-hidden shadow-material-4">
                 <CustomerTableSkeleton />
               </div>
               <CustomerPagination />
             </div>
           ) : (
-            <div className="space-y-4 sm:space-y-6">
+            <div className="space-y-3 sm:space-y-4">
               <div className="glass-effect rounded-2xl overflow-hidden shadow-material-4">
+                <CustomerFilters compact />
                 <CustomerTable table={table} />
               </div>
               <CustomerPagination />

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -196,10 +196,12 @@ export default function AdminDashboard() {
 
   return (
     <DashboardLayout breadcrumbs={breadcrumbs} tableInstance={table}>
-      <div className="space-y-6 sm:space-y-8">
+      <div className="space-y-5 sm:space-y-6">
         {/* Header Section */}
         <div className="stagger-item">
-          <h1 className="text-xl sm:text-heading font-bold text-[#212121] mb-1 sm:mb-2">
+          <h1
+            className="text-xl sm:text-heading font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent mb-1 sm:mb-2"
+          >
             Admin Dashboard
           </h1>
           <p className="text-sm sm:text-subtitle text-gray-600 font-normal">
@@ -244,12 +246,6 @@ export default function AdminDashboard() {
           <ExcelUpload onImport={handleExcelImport} />
         </div>
 
-        {/* Filters Section */}
-        <div className="stagger-item">
-          <ParcelFilters />
-        </div>
-
-
         {/* Action Header */}
         <div className="stagger-item flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <h2 className="text-lg sm:text-title font-semibold text-[#212121]">
@@ -257,27 +253,27 @@ export default function AdminDashboard() {
           </h2>
           <Button
             onClick={() => {
-              setEditingParcel(null); // Ensure form is in 'add' mode
-              setShowParcelForm(true);
+              setEditingParcel(null)
+              setShowParcelForm(true)
             }}
-            className="ripple bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium px-4 sm:px-6 py-2 sm:py-3 rounded-xl shadow-material-4 transition-all duration-300 hover:shadow-material-8 touch-target w-full sm:w-auto"
+            className="ripple bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-medium px-4 sm:px-5 py-2 rounded-lg shadow-material-4 transition-all duration-300 hover:shadow-material-8 touch-target w-full sm:w-auto"
           >
-            <Plus className="h-4 w-4 sm:h-5 sm:w-5 mr-2" />
-            <span className="text-sm sm:text-base">เพิ่มรายการสินค้า</span>
+            <Plus className="h-4 w-4 mr-2" />
+            <span className="text-sm">เพิ่มรายการสินค้า</span>
           </Button>
         </div>
 
         {/* Table Section */}
         <div className="stagger-item">
           {loading ? (
-            <div className="space-y-4 sm:space-y-6">
+            <div className="space-y-3 sm:space-y-4">
               <div className="glass-effect rounded-2xl overflow-hidden shadow-material-4">
                 <ParcelTableSkeleton />
               </div>
               <ParcelPagination /> {/* Consider if pagination should also have a skeleton or be hidden */}
             </div>
           ) : (
-            <div className="space-y-4 sm:space-y-6">
+            <div className="space-y-3 sm:space-y-4">
               <div className="flex flex-col sm:flex-row gap-2 items-center">
                 <Button
                   onClick={handleBulkDeliver}
@@ -290,6 +286,7 @@ export default function AdminDashboard() {
                 <ColumnVisibilityDropdown table={table} />
               </div>
               <div className="glass-effect rounded-2xl overflow-hidden shadow-material-4">
+                <ParcelFilters compact />
                 <ParcelTable<Parcel> table={table} />
               </div>
               <ParcelPagination />

--- a/web/components/admin/customer/customer-filters.tsx
+++ b/web/components/admin/customer/customer-filters.tsx
@@ -10,7 +10,11 @@ import { useCustomerStore } from "@/stores/customer-store";
 import { UserStatus } from "@/lib/types"; // Assuming UserStatus is defined here
 import { Search, X } from "lucide-react";
 
-export function CustomerFilters() {
+interface CustomerFiltersProps {
+  compact?: boolean
+}
+
+export function CustomerFilters({ compact = false }: CustomerFiltersProps) {
   const { refetch } = useCustomers();
   const filters = useCustomerStore((state) => state.filters);
   const setFilters = useCustomerStore((state) => state.setFilters);
@@ -51,10 +55,8 @@ export function CustomerFilters() {
   };
 
 
-  return (
-    <Card className="glass-effect border-0 rounded-xl sm:rounded-2xl shadow-material-4 overflow-hidden">
-      <CardContent className="p-4 sm:p-6">
-        <div className="flex flex-wrap gap-4 items-end">
+  const content = (
+    <div className="flex flex-wrap gap-3 items-end">
           <div className="w-full sm:w-64 md:w-72">
             <Input
               placeholder="ค้นหา ชื่อ, อีเมล..."
@@ -93,7 +95,15 @@ export function CustomerFilters() {
             </Button>
           </div>
         </div>
-      </CardContent>
+  )
+
+  if (compact) {
+    return <div className="p-4 sm:p-6 border-b">{content}</div>
+  }
+
+  return (
+    <Card className="glass-effect border-0 rounded-xl sm:rounded-2xl shadow-material-4 overflow-hidden">
+      <CardContent className="p-4 sm:p-6">{content}</CardContent>
     </Card>
-  );
+  )
 }

--- a/web/components/admin/customer/customer-table-columns.tsx
+++ b/web/components/admin/customer/customer-table-columns.tsx
@@ -4,7 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Customer, UserStatus } from "@/lib/types"; // Assuming Customer and UserStatus are in types.ts
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowUpDown } from "lucide-react";
+import { ArrowUpDown, KeyRound, PencilLine } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // Define a type for the props if you need to pass callbacks for actions
@@ -98,19 +98,20 @@ export const getCustomerColumns = ({ onEdit, onResetPassword }: CustomerTableAct
       return (
         <div className="flex space-x-2">
           <Button
-            variant="outline" // Changed to outline for less emphasis than destructive
-            size="sm"
-            className="border-yellow-500 text-yellow-700 hover:bg-yellow-50 hover:text-yellow-800" // Warning style
+            variant="outline"
+            size="icon"
+            className="border-yellow-500 text-yellow-700 hover:bg-yellow-50 hover:text-yellow-800"
             onClick={() => onResetPassword(customer)}
           >
-            Reset Password
+            <KeyRound className="h-4 w-4" />
           </Button>
           <Button
-            variant="link"
-            size="sm"
+            variant="ghost"
+            size="icon"
             onClick={() => onEdit(customer)}
+            className="text-blue-600 hover:bg-blue-50"
           >
-            Edit
+            <PencilLine className="h-4 w-4" />
           </Button>
         </div>
       );

--- a/web/components/admin/customer/customer-table-skeleton.tsx
+++ b/web/components/admin/customer/customer-table-skeleton.tsx
@@ -1,5 +1,5 @@
 import { TableSkeleton } from "@/components/shared/table-skeleton";
 
 export function CustomerTableSkeleton() {
-  return <TableSkeleton columns={4} />;
+  return <TableSkeleton columns={4} compact />
 }

--- a/web/components/admin/customer/customer-table.tsx
+++ b/web/components/admin/customer/customer-table.tsx
@@ -4,9 +4,15 @@ import type { Table as TanstackTable } from "@tanstack/react-table";
 import { DataTable } from "@/components/shared/data-table";
 
 interface DataTableProps<TData> {
-  table: TanstackTable<TData>;
+  table: TanstackTable<TData>
 }
 
 export function CustomerTable<TData>({ table }: DataTableProps<TData>) {
-  return <DataTable table={table} noDataMessage="No customers found." />;
+  return (
+    <DataTable
+      table={table}
+      noDataMessage="No customers found."
+      compact
+    />
+  )
 }

--- a/web/components/parcel/parcel-filters.tsx
+++ b/web/components/parcel/parcel-filters.tsx
@@ -10,7 +10,11 @@ import { Search, RotateCcw } from "lucide-react"
 import { DateRangePicker } from "@/components/ui/date-range-picker"
 import type { DateRange } from "react-day-picker"
 
-export function ParcelFilters() {
+interface ParcelFiltersProps {
+  compact?: boolean
+}
+
+export function ParcelFilters({ compact = false }: ParcelFiltersProps) {
   const { filters, setFilters, resetFilters } = useParcelStore()
   const [localFilters, setLocalFilters] = useState(filters)
 
@@ -62,10 +66,8 @@ export function ParcelFilters() {
     setDateRange(undefined)
   }
 
-  return (
-    <Card className="glass-effect border-0 rounded-xl sm:rounded-2xl shadow-material-4 overflow-hidden">
-      <CardContent className="p-4 sm:p-6">
-        <div className="flex flex-wrap gap-4 items-end">
+  const content = (
+    <div className="flex flex-wrap gap-3 items-end">
           {/* Search Input - Reduced width */}
           <div className="w-full sm:w-64 md:w-72">
             <Input
@@ -139,7 +141,15 @@ export function ParcelFilters() {
             </Button>
           </div>
         </div>
-      </CardContent>
+  )
+
+  if (compact) {
+    return <div className="p-4 sm:p-6 border-b">{content}</div>
+  }
+
+  return (
+    <Card className="glass-effect border-0 rounded-xl sm:rounded-2xl shadow-material-4 overflow-hidden">
+      <CardContent className="p-4 sm:p-6">{content}</CardContent>
     </Card>
   )
 }

--- a/web/components/parcel/parcel-table-skeleton.tsx
+++ b/web/components/parcel/parcel-table-skeleton.tsx
@@ -1,5 +1,5 @@
 import { TableSkeleton } from "@/components/shared/table-skeleton";
 
 export function ParcelTableSkeleton() {
-  return <TableSkeleton columns={10} />;
+  return <TableSkeleton columns={10} compact />
 }

--- a/web/components/parcel/parcel-table.tsx
+++ b/web/components/parcel/parcel-table.tsx
@@ -8,5 +8,5 @@ interface ParcelTableProps<TData> {
 }
 
 export function ParcelTable<TData>({ table }: ParcelTableProps<TData>) {
-  return <DataTable table={table} />
+  return <DataTable table={table} compact />
 }

--- a/web/components/shared/data-table.tsx
+++ b/web/components/shared/data-table.tsx
@@ -9,19 +9,27 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { cn } from "@/lib/utils"
 
 interface DataTableProps<TData> {
   table: TanStackTable<TData>
   noDataMessage?: React.ReactNode
   className?: string
+  compact?: boolean
 }
 
-export function DataTable<TData>({ table, noDataMessage, className }: DataTableProps<TData>) {
+export function DataTable<TData>({ table, noDataMessage, className, compact = false }: DataTableProps<TData>) {
   const hasRows = table.getRowModel().rows.length > 0
 
   return (
     <div className="rounded-md border bg-white">
-      <Table className={className ?? "min-w-[1200px]"}>
+      <Table
+        className={cn(
+          className ?? "min-w-[1200px]",
+          compact &&
+            "[&_th]:h-10 [&_th]:px-3 [&_td]:px-3 [&_td]:py-2 text-sm"
+        )}
+      >
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id} className="bg-gray-50">

--- a/web/components/shared/table-skeleton.tsx
+++ b/web/components/shared/table-skeleton.tsx
@@ -7,17 +7,25 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { cn } from "@/lib/utils"
 
 interface TableSkeletonProps {
   rows?: number
   columns?: number
   className?: string
+  compact?: boolean
 }
 
-export function TableSkeleton({ rows = 8, columns = 5, className }: TableSkeletonProps) {
+export function TableSkeleton({ rows = 8, columns = 5, className, compact = false }: TableSkeletonProps) {
   return (
     <div className="rounded-md border bg-white">
-      <Table className={className ?? "min-w-[1200px]"}>
+      <Table
+        className={cn(
+          className ?? "min-w-[1200px]",
+          compact &&
+            "[&_th]:h-10 [&_th]:px-3 [&_td]:px-3 [&_td]:py-2 text-sm"
+        )}
+      >
         <TableHeader>
           <TableRow className="bg-gray-50">
             {Array.from({ length: columns }).map((_, index) => (


### PR DESCRIPTION
## Summary
- add `compact` display option for data table and skeletons
- refactor admin pages to use compact tables with inline filters
- tweak headings and buttons for a brighter minimal look
- make customer table actions icon based

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e5e2a278833092c9beb9ef07fa56