### PR TITLE
Add parcel images

### DIFF
--- a/app/api/utils.ts
+++ b/app/api/utils.ts
@@ -127,6 +127,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-15T10:00:00Z",
     updatedAt: "2024-01-15T10:00:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "2",
@@ -144,6 +149,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "unpaid",
     createdAt: "2024-01-16T09:30:00Z",
     updatedAt: "2024-01-16T09:30:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "3",
@@ -162,6 +172,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-17T11:15:00Z",
     updatedAt: "2024-01-17T11:15:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "4",
@@ -179,6 +194,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "partial",
     createdAt: "2024-01-18T14:20:00Z",
     updatedAt: "2024-01-18T14:20:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "5",
@@ -197,6 +217,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-19T09:45:00Z",
     updatedAt: "2024-01-19T09:45:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "6",
@@ -214,6 +239,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "unpaid",
     createdAt: "2024-01-20T16:30:00Z",
     updatedAt: "2024-01-20T16:30:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "7",
@@ -232,6 +262,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-21T11:10:00Z",
     updatedAt: "2024-01-21T11:10:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "8",
@@ -250,6 +285,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-22T13:25:00Z",
     updatedAt: "2024-01-22T13:25:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "9",
@@ -267,6 +307,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "unpaid",
     createdAt: "2024-01-23T08:15:00Z",
     updatedAt: "2024-01-23T08:15:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "10",
@@ -285,6 +330,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "partial",
     createdAt: "2024-01-24T15:40:00Z",
     updatedAt: "2024-01-24T15:40:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   // Additional customer parcels for better UI testing
   {
@@ -303,6 +353,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "unpaid",
     createdAt: "2024-01-25T09:00:00Z",
     updatedAt: "2024-01-25T09:00:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "12",
@@ -321,6 +376,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-26T14:30:00Z",
     updatedAt: "2024-01-26T14:30:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "13",
@@ -339,6 +399,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-27T11:45:00Z",
     updatedAt: "2024-01-27T11:45:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "14",
@@ -356,6 +421,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "partial",
     createdAt: "2024-01-28T16:20:00Z",
     updatedAt: "2024-01-28T16:20:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "15",
@@ -374,6 +444,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-29T10:15:00Z",
     updatedAt: "2024-01-29T10:15:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   // Other customers' parcels
   {
@@ -393,6 +468,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-20T12:30:00Z",
     updatedAt: "2024-01-20T12:30:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "17",
@@ -410,6 +490,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "unpaid",
     createdAt: "2024-01-21T15:45:00Z",
     updatedAt: "2024-01-21T15:45:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "18",
@@ -428,6 +513,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-22T09:20:00Z",
     updatedAt: "2024-01-22T09:20:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "19",
@@ -446,6 +536,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "paid",
     createdAt: "2024-01-23T13:10:00Z",
     updatedAt: "2024-01-23T13:10:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
   {
     id: "20",
@@ -463,6 +558,11 @@ export const mockParcels: Parcel[] = [
     paymentStatus: "unpaid",
     createdAt: "2024-01-24T11:55:00Z",
     updatedAt: "2024-01-24T11:55:00Z",
+    images: [
+      "https://example.com/image1.jpg",
+      "https://example.com/image2.jpg",
+      "https://example.com/image3.jpg",
+    ],
   },
 ]
 export interface ParcelFilterOptions {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -83,6 +83,7 @@ export interface Parcel {
   freight: number
   deliveryMethod: string
   thTracking?: string
+  images?: string[]
   paymentStatus: "unpaid" | "paid" | "partial"
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## Summary
- extend `Parcel` interface with `images` field
- mock parcel dataset now includes placeholder image URLs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd22a0c208330b40c9113736e781b