### PR TITLE
Add parcel gallery modal

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -26,6 +26,7 @@ import { ParcelTable } from "@/components/parcel/parcel-table"
 import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"; // Add this line
 import { ParcelPagination } from "@/components/parcel/parcel-pagination"
 import { ParcelDetailModal } from "@/components/parcel/parcel-detail-modal"
+import { ParcelGalleryModal } from "@/components/parcel/parcel-gallery-modal"
 import { ParcelForm } from "@/components/admin/parcel-form"
 import { ExcelUpload } from "@/components/admin/excel-upload"
 import { StatCard } from "@/components/ui/stat-card"
@@ -38,7 +39,7 @@ export default function AdminDashboard() {
   const router = useRouter()
 
   const { loading, refetch, parcels = [] } = useParcels()
-  const { setSelectedParcel, updateParcel } = useParcelStore()
+  const { setSelectedParcel, updateParcel, galleryImages, closeGallery } = useParcelStore()
 
   const [showParcelForm, setShowParcelForm] = useState(false)
   const [sorting, setSorting] = useState<SortingState>([])
@@ -302,6 +303,11 @@ export default function AdminDashboard() {
         </div>
 
         <ParcelDetailModal />
+        <ParcelGalleryModal
+          images={galleryImages}
+          open={galleryImages.length > 0}
+          onClose={closeGallery}
+        />
         {showParcelForm && ( // Conditionally render ParcelForm to ensure useEffect in ParcelForm re-runs correctly on open
           <ParcelForm
             open={showParcelForm}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -24,13 +24,16 @@ import { ParcelTable } from "@/components/parcel/parcel-table"
 import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"; // Add this line
 import { ParcelPagination } from "@/components/parcel/parcel-pagination"
 import { ParcelDetailModal } from "@/components/parcel/parcel-detail-modal"
+import { ParcelGalleryModal } from "@/components/parcel/parcel-gallery-modal"
 import { StatCard } from "@/components/ui/stat-card"
 import { useParcels } from "@/hooks/use-parcels"
+import { useParcelStore } from "@/stores/parcel-store"
 
 export default function CustomerDashboard() {
   const { user, isAuthenticated } = useAuthStore()
   const router = useRouter()
   const { loading, parcels = [], setSelectedParcel } = useParcels()
+  const { galleryImages, closeGallery } = useParcelStore()
 
   const [sorting, setSorting] = useState<SortingState>([])
 
@@ -151,6 +154,11 @@ export default function CustomerDashboard() {
         </div>
 
         <ParcelDetailModal />
+        <ParcelGalleryModal
+          images={galleryImages}
+          open={galleryImages.length > 0}
+          onClose={closeGallery}
+        />
       </div>
     </DashboardLayout>
   );

--- a/components/parcel/parcel-gallery-modal.tsx
+++ b/components/parcel/parcel-gallery-modal.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import Image from "next/image"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel"
+
+interface ParcelGalleryModalProps {
+  images: string[]
+  open: boolean
+  onClose: () => void
+}
+
+export function ParcelGalleryModal({ images, open, onClose }: ParcelGalleryModalProps) {
+  if (images.length === 0) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-3xl">
+        <Carousel className="w-full">
+          <CarouselContent>
+            {images.map((src, idx) => (
+              <CarouselItem key={idx} className="flex justify-center">
+                <Image
+                  src={src}
+                  alt={`parcel-image-${idx}`}
+                  width={800}
+                  height={600}
+                  className="object-contain max-h-[70vh]"
+                />
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          <CarouselPrevious />
+          <CarouselNext />
+        </Carousel>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/stores/parcel-store.ts
+++ b/stores/parcel-store.ts
@@ -9,6 +9,7 @@ interface ParcelState {
   filters: ParcelFilters
   pagination: PaginationState
   selectedParcel: Parcel | null
+  galleryImages: string[]
 
   setParcels: (parcels: Parcel[], total: number) => void
   setLoading: (loading: boolean) => void
@@ -16,6 +17,8 @@ interface ParcelState {
   setFilters: (filters: Partial<ParcelFilters>) => void
   setPagination: (pagination: Partial<PaginationState>) => void
   setSelectedParcel: (parcel: Parcel | null) => void
+  setGalleryImages: (images: string[]) => void
+  closeGallery: () => void
   resetFilters: () => void
   updateParcel: (parcel: Parcel) => void
 }
@@ -41,6 +44,7 @@ export const useParcelStore = create<ParcelState>((set) => ({
   filters: initialFilters,
   pagination: initialPagination,
   selectedParcel: null,
+  galleryImages: [],
   error: null, // Initialized error state
 
   setParcels: (parcels, total) => set({ parcels, total }),
@@ -56,6 +60,8 @@ export const useParcelStore = create<ParcelState>((set) => ({
       pagination: { ...state.pagination, ...newPagination },
     })),
   setSelectedParcel: (selectedParcel) => set({ selectedParcel }),
+  setGalleryImages: (images) => set({ galleryImages: images }),
+  closeGallery: () => set({ galleryImages: [] }),
   resetFilters: () => set({ filters: initialFilters, pagination: initialPagination }),
   updateParcel: (parcel) =>
     set((state) => {


### PR DESCRIPTION
## Summary
- implement `ParcelGalleryModal` to display parcel images in a carousel dialog
- extend parcel store with gallery state and actions
- use the new gallery modal on admin and customer dashboards

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd22bbfd08330a55218e3ac433b3d