### PR TITLE
Add placeholder thumbnail and gallery modal

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -26,6 +26,7 @@ import { ParcelTable } from "@/components/parcel/parcel-table"
 import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"; // Add this line
 import { ParcelPagination } from "@/components/parcel/parcel-pagination"
 import { ParcelDetailModal } from "@/components/parcel/parcel-detail-modal"
+import { ParcelGalleryModal } from "@/components/parcel/parcel-gallery-modal"
 import { ParcelForm } from "@/components/admin/parcel-form"
 import { ExcelUpload } from "@/components/admin/excel-upload"
 import { StatCard } from "@/components/ui/stat-card"
@@ -302,6 +303,7 @@ export default function AdminDashboard() {
         </div>
 
         <ParcelDetailModal />
+        <ParcelGalleryModal />
         {showParcelForm && ( // Conditionally render ParcelForm to ensure useEffect in ParcelForm re-runs correctly on open
           <ParcelForm
             open={showParcelForm}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -24,6 +24,7 @@ import { ParcelTable } from "@/components/parcel/parcel-table"
 import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"; // Add this line
 import { ParcelPagination } from "@/components/parcel/parcel-pagination"
 import { ParcelDetailModal } from "@/components/parcel/parcel-detail-modal"
+import { ParcelGalleryModal } from "@/components/parcel/parcel-gallery-modal"
 import { StatCard } from "@/components/ui/stat-card"
 import { useParcels } from "@/hooks/use-parcels"
 
@@ -151,6 +152,7 @@ export default function CustomerDashboard() {
         </div>
 
         <ParcelDetailModal />
+        <ParcelGalleryModal />
       </div>
     </DashboardLayout>
   );

--- a/components/parcel/parcel-gallery-modal.tsx
+++ b/components/parcel/parcel-gallery-modal.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useParcelStore } from "@/stores/parcel-store";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import { DEFAULT_THUMBNAIL } from "@/lib/constants";
+
+export function ParcelGalleryModal() {
+  const { selectedParcel, setSelectedParcel } = useParcelStore();
+
+  if (!selectedParcel) return null;
+
+  const images = selectedParcel.images && selectedParcel.images.length > 0
+    ? selectedParcel.images
+    : [DEFAULT_THUMBNAIL];
+
+  return (
+    <Dialog open={!!selectedParcel} onOpenChange={() => setSelectedParcel(null)}>
+      <DialogContent className="max-w-2xl">
+        <Carousel className="w-full">
+          <CarouselContent>
+            {images.map((src, idx) => (
+              <CarouselItem key={idx} className="flex justify-center">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={src} alt={`image-${idx}`} className="max-h-[60vh] object-contain" />
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          {images.length > 1 && (
+            <>
+              <CarouselPrevious />
+              <CarouselNext />
+            </>
+          )}
+        </Carousel>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/parcel/parcel-table-columns.tsx
+++ b/components/parcel/parcel-table-columns.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/select";
 import { StatusBadge } from "@/components/ui/status-badge";
 import type { Parcel } from "@/lib/types";
+import { DEFAULT_THUMBNAIL } from "@/lib/constants";
 import {
   type Role, // Import Role type
   isColumnVisible,
@@ -75,6 +76,22 @@ export const getParcelTableColumns = ({
       ),
       enableSorting: false,
       enableHiding: false,
+    }),
+    thumbnail: () => ({
+      id: "thumbnail",
+      header: "ภาพ",
+      cell: ({ row }) => {
+        const imgs = row.original.images;
+        const src = imgs && imgs.length > 0 ? imgs[0] : DEFAULT_THUMBNAIL;
+        return (
+          <img
+            src={src}
+            alt="thumbnail"
+            className="h-12 w-12 object-cover rounded"
+          />
+        );
+      },
+      enableSorting: false,
     }),
     parcelRef: () => ({
       accessorKey: "parcelRef",

--- a/lib/column-configs.ts
+++ b/lib/column-configs.ts
@@ -11,6 +11,7 @@ export interface RoleColumnConfig {
 }
 
 const commonVisibleColumns = [
+  "thumbnail",
   "parcelRef",
   "receiveDate",
   "shipment",
@@ -41,6 +42,7 @@ const baseColumnAccess: { [key: string]: boolean } = {
   thTracking: true,
   paymentStatus: true,
   actions: false,
+  thumbnail: true,
 };
 
 export const ROLES_COLUMN_CONFIG: Record<Role, RoleColumnConfig> = {
@@ -83,6 +85,7 @@ export const isColumnEditable = (role: Role, columnId: string): boolean => {
 
 export const ALL_COLUMN_IDS = [
   "select",
+  "thumbnail",
   "parcelRef",
   "receiveDate",
   "customerCode",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_THUMBNAIL = "/placeholder.jpg";
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,7 @@ export interface Parcel {
   deliveryMethod: string
   thTracking?: string
   paymentStatus: "unpaid" | "paid" | "partial"
+  images?: string[]
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## Summary
- define `DEFAULT_THUMBNAIL` constant
- extend `Parcel` type with optional images
- expose new `thumbnail` column in configs and table
- implement `ParcelGalleryModal`
- show gallery modal on admin and dashboard pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd22e8f688330b27a86416f090da7