### PR TITLE
Add gallery placeholders using picsum

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useMemo, useCallback } from "react" // Added useMemo and useCallback
+import { useEffect, useState, useMemo, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import {
   useReactTable,
@@ -8,7 +8,7 @@ import {
   getSortedRowModel,
   type ColumnDef,
   type SortingState,
-  type RowSelectionState, // Added for row selection
+  type RowSelectionState,
 } from "@tanstack/react-table"
 
 import { useAuthStore } from "@/stores/auth-store"
@@ -23,14 +23,15 @@ import { showToast } from '@/lib/toast-utils'; // Import showToast
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { ParcelFilters } from "@/components/parcel/parcel-filters"
 import { ParcelTable } from "@/components/parcel/parcel-table"
-import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"; // Add this line
+import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"
 import { ParcelPagination } from "@/components/parcel/parcel-pagination"
 import { ParcelDetailModal } from "@/components/parcel/parcel-detail-modal"
+import { ParcelGalleryModal } from "@/components/parcel/parcel-gallery-modal"
 import { ParcelForm } from "@/components/admin/parcel-form"
 import { ExcelUpload } from "@/components/admin/excel-upload"
 import { StatCard } from "@/components/ui/stat-card"
 import { Button } from "@/components/ui/button"
-import { Plus, Package, DollarSign, Users, TrendingUp, PackageCheck } from "lucide-react" // Added PackageCheck
+import { Plus, Package, DollarSign, Users, TrendingUp, PackageCheck } from "lucide-react"
 
 export default function AdminDashboard() {
   console.log('==== Admin Dashboard Page ====')
@@ -302,6 +303,7 @@ export default function AdminDashboard() {
         </div>
 
         <ParcelDetailModal />
+        <ParcelGalleryModal />
         {showParcelForm && ( // Conditionally render ParcelForm to ensure useEffect in ParcelForm re-runs correctly on open
           <ParcelForm
             open={showParcelForm}

--- a/app/api/utils.ts
+++ b/app/api/utils.ts
@@ -109,7 +109,7 @@ export function getCustomerListResponse(options: CustomerFilterOptions = {}): Ap
   };
 }
 
-export const mockParcels: Parcel[] = [
+const baseMockParcels: Omit<Parcel, "images">[] = [
   {
     id: "1",
     parcelRef: "P2024001",
@@ -464,7 +464,15 @@ export const mockParcels: Parcel[] = [
     createdAt: "2024-01-24T11:55:00Z",
     updatedAt: "2024-01-24T11:55:00Z",
   },
-]
+];
+
+export const mockParcels: Parcel[] = baseMockParcels.map((p) => ({
+  ...p,
+  images: [
+    `https://picsum.photos/seed/${p.id}-1/600/400`,
+    `https://picsum.photos/seed/${p.id}-2/600/400`,
+  ],
+}));
 export interface ParcelFilterOptions {
   page?: number;
   pageSize?: number;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -21,9 +21,10 @@ import { getParcelTableColumns } from "@/components/parcel/parcel-table-columns"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { ParcelFilters } from "@/components/parcel/parcel-filters"
 import { ParcelTable } from "@/components/parcel/parcel-table"
-import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"; // Add this line
+import { ParcelTableSkeleton } from "@/components/parcel/parcel-table-skeleton"
 import { ParcelPagination } from "@/components/parcel/parcel-pagination"
 import { ParcelDetailModal } from "@/components/parcel/parcel-detail-modal"
+import { ParcelGalleryModal } from "@/components/parcel/parcel-gallery-modal"
 import { StatCard } from "@/components/ui/stat-card"
 import { useParcels } from "@/hooks/use-parcels"
 
@@ -151,6 +152,7 @@ export default function CustomerDashboard() {
         </div>
 
         <ParcelDetailModal />
+        <ParcelGalleryModal />
       </div>
     </DashboardLayout>
   );

--- a/components/parcel/parcel-gallery-modal.tsx
+++ b/components/parcel/parcel-gallery-modal.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useParcelStore } from "@/stores/parcel-store";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import { DEFAULT_THUMBNAIL } from "@/lib/constants";
+
+export function ParcelGalleryModal() {
+  const { selectedParcel, setSelectedParcel } = useParcelStore();
+
+  if (!selectedParcel) return null;
+
+  const images = selectedParcel.images && selectedParcel.images.length > 0
+    ? selectedParcel.images
+    : [DEFAULT_THUMBNAIL];
+
+  return (
+    <Dialog open={!!selectedParcel} onOpenChange={() => setSelectedParcel(null)}>
+      <DialogContent className="max-w-2xl">
+        <Carousel className="w-full">
+          <CarouselContent>
+            {images.map((src, idx) => (
+              <CarouselItem key={idx} className="flex justify-center">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={src} alt={`image-${idx}`} className="max-h-[60vh] object-contain" />
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          {images.length > 1 && (
+            <>
+              <CarouselPrevious />
+              <CarouselNext />
+            </>
+          )}
+        </Carousel>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/components/parcel/parcel-table-columns.tsx
+++ b/components/parcel/parcel-table-columns.tsx
@@ -12,12 +12,13 @@ import {
 } from "@/components/ui/select";
 import { StatusBadge } from "@/components/ui/status-badge";
 import type { Parcel } from "@/lib/types";
+import { DEFAULT_THUMBNAIL } from "@/lib/constants";
 import {
-  type Role, // Import Role type
+  type Role,
   isColumnVisible,
   isColumnEditable,
-  ALL_COLUMN_IDS // Import ALL_COLUMN_IDS
-} from "@/lib/column-configs"; // Import new configs
+  ALL_COLUMN_IDS
+} from "@/lib/column-configs";
 
 const statusOptions: Parcel["status"][] = [
   "pending",
@@ -32,7 +33,6 @@ export const getSortIcon = (isSorted: false | "asc" | "desc") => {
   return <ArrowUpDown className="ml-2 h-4 w-4" />;
 };
 
-// Add userRole to the props
 interface GetParcelTableColumnsProps {
   userRole: Role;
   setSelectedParcel: (parcel: Parcel) => void;
@@ -75,6 +75,22 @@ export const getParcelTableColumns = ({
       ),
       enableSorting: false,
       enableHiding: false,
+    }),
+    thumbnail: () => ({
+      id: "thumbnail",
+      header: "ภาพ",
+      cell: ({ row }) => {
+        const imgs = row.original.images;
+        const src = imgs && imgs.length > 0 ? imgs[0] : DEFAULT_THUMBNAIL;
+        return (
+          <img
+            src={src}
+            alt="thumbnail"
+            className="h-12 w-12 object-cover rounded"
+          />
+        );
+      },
+      enableSorting: false,
     }),
     parcelRef: () => ({
       accessorKey: "parcelRef",

--- a/lib/column-configs.ts
+++ b/lib/column-configs.ts
@@ -11,6 +11,7 @@ export interface RoleColumnConfig {
 }
 
 const commonVisibleColumns = [
+  "thumbnail",
   "parcelRef",
   "receiveDate",
   "shipment",
@@ -41,6 +42,7 @@ const baseColumnAccess: { [key: string]: boolean } = {
   thTracking: true,
   paymentStatus: true,
   actions: false,
+  thumbnail: true,
 };
 
 export const ROLES_COLUMN_CONFIG: Record<Role, RoleColumnConfig> = {
@@ -83,6 +85,7 @@ export const isColumnEditable = (role: Role, columnId: string): boolean => {
 
 export const ALL_COLUMN_IDS = [
   "select",
+  "thumbnail",
   "parcelRef",
   "receiveDate",
   "customerCode",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_THUMBNAIL = "/placeholder.jpg";
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,7 @@ export interface Parcel {
   deliveryMethod: string
   thTracking?: string
   paymentStatus: "unpaid" | "paid" | "partial"
+  images?: string[]
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## Summary
- clean up inline comments in page imports
- add `baseMockParcels` dataset and map it to provide picsum placeholder images
- use placeholder constant for table and gallery components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd22e8f688330b27a86416f090da7