### PR TITLE
Refactor parcel gallery

### DIFF
--- a/components/parcel/parcel-gallery-modal.tsx
+++ b/components/parcel/parcel-gallery-modal.tsx
@@ -1,111 +1,45 @@
 "use client"
 
-import Image from "next/image"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
-import { useState, useEffect } from "react"
-
-interface LoremPicsumImage {
-  id: string
-  author: string
-  width: number
-  height: number
-  url: string
-  download_url: string
-}
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { DEFAULT_THUMBNAIL } from "@/lib/constants"
+import { PhotoProvider, PhotoView } from "react-photo-view"
+import 'react-photo-view/dist/react-photo-view.css'
 
 interface ParcelGalleryModalProps {
-  images: string[] // Keep existing prop as a fallback
+  images: string[]
   open: boolean
   onClose: () => void
 }
 
-export function ParcelGalleryModal({ images: propImages, open, onClose }: ParcelGalleryModalProps) {
-  const [enlargedImage, setEnlargedImage] = useState<string | null>(null)
-  const [fetchedImages, setFetchedImages] = useState<string[]>([])
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (open) {
-      const fetchImages = async () => {
-        setIsLoading(true)
-        setError(null)
-        try {
-          const response = await fetch("https://picsum.photos/v2/list?page=1&limit=6")
-          if (!response.ok) {
-            throw new Error(`Failed to fetch images: ${response.statusText}`)
-          }
-          const data: LoremPicsumImage[] = await response.json()
-          setFetchedImages(data.map(img => img.download_url))
-        } catch (err) {
-          setError(err instanceof Error ? err.message : "An unknown error occurred")
-          setFetchedImages([]) // Clear any previously fetched images on error
-        } finally {
-          setIsLoading(false)
-        }
-      }
-      fetchImages()
-    }
-  }, [open])
-
-  const displayImages = fetchedImages.length > 0 ? fetchedImages : propImages
-
-  if (displayImages.length === 0 && !isLoading && !error) return null
-  if (isLoading) {
-    return (
-      <Dialog open={open} onOpenChange={onClose}>
-        <DialogContent className="max-w-3xl flex items-center justify-center h-48">
-          <div>Loading images...</div>
-        </DialogContent>
-      </Dialog>
-    )
-  }
-
-  if (error) {
-    return (
-      <Dialog open={open} onOpenChange={onClose}>
-        <DialogContent className="max-w-3xl flex items-center justify-center h-48">
-          <div>Error: {error}</div>
-        </DialogContent>
-      </Dialog>
-    )
-  }
-
-  if (displayImages.length === 0) return null
-
+export function ParcelGalleryModal({ images, open, onClose }: ParcelGalleryModalProps) {
+  const displayImages = images && images.length > 0 ? images : []
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-3xl">
-        <div className="flex flex-wrap gap-4">
-          {displayImages.map((src, idx) => (
-            <div
-              key={idx}
-              className="w-[100px] h-[100px] relative cursor-pointer"
-              onMouseEnter={() => setEnlargedImage(src)}
-              onMouseLeave={() => setEnlargedImage(null)}
-            >
-              <Image
-                src={src}
-                alt={`parcel-image-${idx}`}
-                layout="fill"
-                objectFit="cover"
-                className="rounded-md"
-              />
+        <DialogHeader>
+          <DialogTitle>รูปภาพพัสดุ</DialogTitle>
+        </DialogHeader>
+        {displayImages.length > 0 ? (
+          <PhotoProvider>
+            <div className="grid grid-cols-3 gap-4">
+              {displayImages.map((src, idx) => (
+                <PhotoView key={idx} src={src}>
+                  <img
+                    src={src}
+                    alt={`parcel-image-${idx}`}
+                    className="h-24 w-24 cursor-pointer rounded object-cover"
+                  />
+                </PhotoView>
+              ))}
             </div>
-          ))}
-        </div>
-        {enlargedImage && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-            <div className="relative w-[80vw] h-[80vh]">
-              <Image
-                src={enlargedImage}
-                alt="enlarged-parcel-image"
-                layout="fill"
-                objectFit="contain"
-              />
-            </div>
-          </div>
+          </PhotoProvider>
+        ) : (
+          <img
+            src={DEFAULT_THUMBNAIL}
+            alt="no image"
+            className="mx-auto max-h-[70vh] object-contain"
+          />
         )}
       </DialogContent>
     </Dialog>

--- a/components/parcel/parcel-table-columns.tsx
+++ b/components/parcel/parcel-table-columns.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown, ArrowUp, ArrowDown, Loader2, FilePenLine } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -11,14 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { StatusBadge } from "@/components/ui/status-badge";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "@/components/ui/carousel";
+
 import type { Parcel } from "@/lib/types";
 import { DEFAULT_THUMBNAIL } from "@/lib/constants";
 import {
@@ -27,6 +19,7 @@ import {
   isColumnEditable,
   ALL_COLUMN_IDS // Import ALL_COLUMN_IDS
 } from "@/lib/column-configs"; // Import new configs
+import { useParcelStore } from "@/stores/parcel-store";
 
 const statusOptions: Parcel["status"][] = [
   "pending",
@@ -111,57 +104,19 @@ export const getParcelTableColumns = ({
       id: "images",
       header: "รูปภาพ",
       cell: ({ row }) => {
-        const parcel = row.original;
-        const [open, setOpen] = useState(false);
-        const images = parcel.images ?? [];
-        const thumb = images[0] || "/placeholder.jpg";
+        const parcel = row.original
+        const images = parcel.images ?? []
+        const thumb = images[0] || DEFAULT_THUMBNAIL
+        const setGalleryImages = useParcelStore(state => state.setGalleryImages)
+
         return (
-          <>
-            <img
-              src={thumb}
-              alt="thumbnail"
-              className="h-12 w-12 cursor-pointer rounded object-cover"
-              onClick={() => setOpen(true)}
-            />
-            <Dialog open={open} onOpenChange={setOpen}>
-              <DialogContent className="max-w-3xl">
-                <DialogHeader>
-                  <DialogTitle>รูปภาพพัสดุ</DialogTitle>
-                </DialogHeader>
-                {images.length > 0 ? (
-                  <Carousel className="w-full">
-                    <CarouselContent>
-                      {images.map((src, idx) => (
-                        <CarouselItem
-                          key={idx}
-                          className="flex items-center justify-center"
-                        >
-                          <img
-                            src={src}
-                            alt={`parcel-image-${idx}`}
-                            className="max-h-[70vh] object-contain"
-                          />
-                        </CarouselItem>
-                      ))}
-                    </CarouselContent>
-                    {images.length > 1 && (
-                      <>
-                        <CarouselPrevious />
-                        <CarouselNext />
-                      </>
-                    )}
-                  </Carousel>
-                ) : (
-                  <img
-                    src="/placeholder.jpg"
-                    alt="no image"
-                    className="max-h-[70vh] object-contain"
-                  />
-                )}
-              </DialogContent>
-            </Dialog>
-          </>
-        );
+          <img
+            src={thumb}
+            alt="thumbnail"
+            className="h-12 w-12 cursor-pointer rounded object-cover"
+            onClick={() => setGalleryImages(images)}
+          />
+        )
       },
       enableSorting: false,
     }),

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-dropzone": "latest",
     "react-hook-form": "latest",
     "react-resizable-panels": "^2.1.7",
+    "react-photo-view": "latest",
     "recharts": "2.15.0",
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",


### PR DESCRIPTION
## Summary
- refactor `ParcelGalleryModal` to use `react-photo-view` for a nicer gallery
- open gallery from the parcel table by passing image URLs directly
- update dependencies to include `react-photo-view`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de06824508330b4bec9f82f866e09